### PR TITLE
Add debug level

### DIFF
--- a/logsip.go
+++ b/logsip.go
@@ -18,6 +18,8 @@ type Logger struct {
 	FatalPrefix string
 	InfoPrefix  string
 	PanicPrefix string
+	DebugPrefix string
+	DebugMode   bool
 	*log.Logger
 }
 
@@ -33,6 +35,7 @@ func Default() *Logger {
 		InfoPrefix:  color.New(color.FgCyan).SprintFunc()("==> Info: "),
 		FatalPrefix: color.New(color.FgRed).SprintFunc()("==> Fatal: "),
 		PanicPrefix: color.New(color.FgRed).SprintFunc()("==> Panic: "),
+		DebugPrefix: color.New(color.FgMagenta).SprintFunc()("==> Debug: "),
 		Logger:      log.New(os.Stdout, "", 0),
 	}
 }
@@ -40,6 +43,11 @@ func Default() *Logger {
 // Info works just like log.Print however adds the Info prefix.
 func (l *Logger) Info(v ...interface{}) {
 	l.Print(l.InfoPrefix + fmt.Sprint(v...))
+}
+
+// Debug works just like log.Print however adds the Debug prefix.
+func (l *Logger) Debug(v ...interface{}) {
+	l.Print(l.DebugPrefix + fmt.Sprint(v...))
 }
 
 // Warn works just like log.Print however adds the Warn prefix.
@@ -62,6 +70,11 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 	l.Print(l.InfoPrefix + fmt.Sprintf(format, v...))
 }
 
+// Debugf works just like log.Printf however adds the Debug prefix.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	l.Print(l.DebugPrefix + fmt.Sprintf(format, v...))
+}
+
 // Warnf works just like log.Printf however adds the Warn prefix.
 func (l *Logger) Warnf(format string, v ...interface{}) {
 	l.Print(l.WarnPrefix + fmt.Sprintf(format, v...))
@@ -80,6 +93,11 @@ func (l *Logger) Panicf(format string, v ...interface{}) {
 // Infoln works just like log.Println however adds the Info prefix
 func (l *Logger) Infoln(v ...interface{}) {
 	l.Println(l.InfoPrefix + fmt.Sprint(v...))
+}
+
+// Debugln works just like log.Println however adds the Debug prefix.
+func (l *Logger) Debugln(v ...interface{}) {
+	l.Println(l.DebugPrefix + fmt.Sprint(v...))
 }
 
 // Warnln works just like log.Println however adds the Warnln prefix

--- a/logsip.go
+++ b/logsip.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 )
 
+// Logger is a modified log.Logger which provides logging levels.
 type Logger struct {
 	WarnPrefix  string
 	FatalPrefix string
@@ -20,10 +21,12 @@ type Logger struct {
 	*log.Logger
 }
 
+// New returns a blank Logger so you can define your own prefixes.
 func New(out io.Writer) *Logger {
 	return &Logger{Logger: log.New(out, "", 0)}
 }
 
+// Default returns a new Logger with the default color and prefix options.
 func Default() *Logger {
 	return &Logger{
 		WarnPrefix:  color.New(color.FgYellow).SprintFunc()("==> Warn: "),
@@ -34,45 +37,62 @@ func Default() *Logger {
 	}
 }
 
+// Info works just like log.Print however adds the Info prefix.
 func (l *Logger) Info(v ...interface{}) {
 	l.Print(l.InfoPrefix + fmt.Sprint(v...))
 }
+
+// Warn works just like log.Print however adds the Warn prefix.
 func (l *Logger) Warn(v ...interface{}) {
 	l.Print(l.WarnPrefix + fmt.Sprint(v...))
 }
+
+// Fatal works just like log.Fatal however adds the Fatal prefix.
 func (l *Logger) Fatal(v ...interface{}) {
-	l.Print(l.FatalPrefix + fmt.Sprint(v...))
-	os.Exit(1)
+	l.Fatal(l.FatalPrefix + fmt.Sprint(v...))
 }
+
+// Panic works just like log.Panic however adds the Panic prefix.
 func (l *Logger) Panic(v ...interface{}) {
-	l.Print(l.PanicPrefix + fmt.Sprint(v...))
-	panic(l)
+	l.Panic(l.PanicPrefix + fmt.Sprint(v...))
 }
+
+// Infof works just like log.Printf however adds the Info prefix.
 func (l *Logger) Infof(format string, v ...interface{}) {
 	l.Print(l.InfoPrefix + fmt.Sprintf(format, v...))
 }
+
+// Warnf works just like log.Printf however adds the Warn prefix.
 func (l *Logger) Warnf(format string, v ...interface{}) {
 	l.Print(l.WarnPrefix + fmt.Sprintf(format, v...))
 }
+
+// Fatalf works just like log.Fatalf however adds the Fatal prefix.
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	l.Print(l.FatalPrefix + fmt.Sprintf(format, v...))
-	os.Exit(1)
+	l.Fatalf(l.FatalPrefix + fmt.Sprintf(format, v...))
 }
+
+// Panicf works just like log.Panicf however adds the Panic prefix.
 func (l *Logger) Panicf(format string, v ...interface{}) {
-	l.Print(l.PanicPrefix + fmt.Sprintf(format, v...))
-	panic(l)
+	l.Panicf(l.PanicPrefix + fmt.Sprintf(format, v...))
 }
+
+// Infoln works just like log.Println however adds the Info prefix
 func (l *Logger) Infoln(v ...interface{}) {
 	l.Println(l.InfoPrefix + fmt.Sprint(v...))
 }
+
+// Warnln works just like log.Println however adds the Warnln prefix
 func (l *Logger) Warnln(v ...interface{}) {
 	l.Println(l.WarnPrefix + fmt.Sprint(v...))
 }
+
+// Fatalln works just like log.Fatalln however adds the Fatal prefix
 func (l *Logger) Fatalln(v ...interface{}) {
-	l.Println(l.FatalPrefix + fmt.Sprint(v...))
-	os.Exit(1)
+	l.Fatalln(l.FatalPrefix + fmt.Sprint(v...))
 }
+
+// Panicln works just like log.Panicln however adds the Panic prefix
 func (l *Logger) Panicln(v ...interface{}) {
-	l.Println(l.PanicPrefix + fmt.Sprint(v...))
-	panic(l)
+	l.Panicln(l.PanicPrefix + fmt.Sprint(v...))
 }

--- a/logsip.go
+++ b/logsip.go
@@ -36,6 +36,7 @@ func Default() *Logger {
 		FatalPrefix: color.New(color.FgRed).SprintFunc()("==> Fatal: "),
 		PanicPrefix: color.New(color.FgRed).SprintFunc()("==> Panic: "),
 		DebugPrefix: color.New(color.FgMagenta).SprintFunc()("==> Debug: "),
+		DebugMode:   false,
 		Logger:      log.New(os.Stdout, "", 0),
 	}
 }
@@ -47,7 +48,9 @@ func (l *Logger) Info(v ...interface{}) {
 
 // Debug works just like log.Print however adds the Debug prefix.
 func (l *Logger) Debug(v ...interface{}) {
-	l.Print(l.DebugPrefix + fmt.Sprint(v...))
+	if l.DebugMode {
+		l.Print(l.DebugPrefix + fmt.Sprint(v...))
+	}
 }
 
 // Warn works just like log.Print however adds the Warn prefix.
@@ -72,7 +75,9 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 
 // Debugf works just like log.Printf however adds the Debug prefix.
 func (l *Logger) Debugf(format string, v ...interface{}) {
-	l.Print(l.DebugPrefix + fmt.Sprintf(format, v...))
+	if l.DebugMode {
+		l.Print(l.DebugPrefix + fmt.Sprintf(format, v...))
+	}
 }
 
 // Warnf works just like log.Printf however adds the Warn prefix.
@@ -97,7 +102,9 @@ func (l *Logger) Infoln(v ...interface{}) {
 
 // Debugln works just like log.Println however adds the Debug prefix.
 func (l *Logger) Debugln(v ...interface{}) {
-	l.Println(l.DebugPrefix + fmt.Sprint(v...))
+	if l.DebugMode {
+		l.Println(l.DebugPrefix + fmt.Sprint(v...))
+	}
 }
 
 // Warnln works just like log.Println however adds the Warnln prefix

--- a/logsip_test.go
+++ b/logsip_test.go
@@ -11,9 +11,8 @@ func TestPrint(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Print("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -21,9 +20,8 @@ func TestPrintf(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Printf("%s", "foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -31,9 +29,8 @@ func TestPrintln(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Println("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -41,9 +38,8 @@ func TestInfo(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Info("foo")
-	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -51,9 +47,8 @@ func TestInfof(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Infof("%s", "foo")
-	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -61,9 +56,8 @@ func TestInfoln(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Infoln("foo")
-	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -71,9 +65,8 @@ func TestWarn(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Warn("foo")
-	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -81,9 +74,8 @@ func TestWarnf(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Warnf("%s", "foo")
-	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -91,39 +83,49 @@ func TestWarnln(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Warnln("foo")
-	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestDebug(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
+	log.DebugMode = true
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Debug("foo")
-	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.DebugPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestDebugf(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
+	log.DebugMode = true
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Debugf("%s", "foo")
-	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.DebugPrefix + "foo\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestDebugln(t *testing.T) {
 	var b bytes.Buffer
 	var log = logsip.Default()
+	log.DebugMode = true
 	log.Logger.SetOutput(&b)
-	const testString = "foo"
 	log.Debugln("foo")
-	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+	if expect := log.DebugPrefix + "foo\n"; b.String() != expect {
+		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
+	}
+}
+func TestDebugMode(t *testing.T) {
+	var b bytes.Buffer
+	var log = logsip.Default()
+	log.DebugMode = false
+	log.Debug("foo")
+	log.Debugln("foo")
+	log.Debugf("%s", "foo")
+	if expect := ""; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }

--- a/logsip_test.go
+++ b/logsip_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestPrint(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Print("foo")
 	if expect := testString + "\n"; b.String() != expect {
@@ -18,7 +19,8 @@ func TestPrint(t *testing.T) {
 }
 func TestPrintf(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Printf("%s", "foo")
 	if expect := testString + "\n"; b.String() != expect {
@@ -27,7 +29,8 @@ func TestPrintf(t *testing.T) {
 }
 func TestPrintln(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Println("foo")
 	if expect := testString + "\n"; b.String() != expect {
@@ -36,55 +39,61 @@ func TestPrintln(t *testing.T) {
 }
 func TestInfo(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Info("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestInfof(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Infof("%s", "foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestInfoln(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Infoln("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.InfoPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestWarn(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Warn("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestWarnf(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Warnf("%s", "foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
 func TestWarnln(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Warnln("foo")
-	if expect := testString + "\n"; b.String() != expect {
+	if expect := log.WarnPrefix + testString + "\n"; b.String() != expect {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
@@ -100,7 +109,8 @@ func TestDebug(t *testing.T) {
 }
 func TestDebugf(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
 	const testString = "foo"
 	log.Debugf("%s", "foo")
 	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
@@ -109,7 +119,6 @@ func TestDebugf(t *testing.T) {
 }
 func TestDebugln(t *testing.T) {
 	var b bytes.Buffer
-	var log = logsip.New(&b)
 	var log = logsip.Default()
 	log.Logger.SetOutput(&b)
 	const testString = "foo"

--- a/logsip_test.go
+++ b/logsip_test.go
@@ -88,3 +88,33 @@ func TestWarnln(t *testing.T) {
 		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
 	}
 }
+func TestDebug(t *testing.T) {
+	var b bytes.Buffer
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
+	const testString = "foo"
+	log.Debug("foo")
+	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
+	}
+}
+func TestDebugf(t *testing.T) {
+	var b bytes.Buffer
+	var log = logsip.New(&b)
+	const testString = "foo"
+	log.Debugf("%s", "foo")
+	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
+	}
+}
+func TestDebugln(t *testing.T) {
+	var b bytes.Buffer
+	var log = logsip.New(&b)
+	var log = logsip.Default()
+	log.Logger.SetOutput(&b)
+	const testString = "foo"
+	log.Debugln("foo")
+	if expect := log.DebugPrefix + testString + "\n"; b.String() != expect {
+		t.Errorf("There's an error here. %s should look like %s", expect, b.String())
+	}
+}


### PR DESCRIPTION
I added an optional debug level which can be turned on / off using Logger.DebugMode. I have added the appropriate tests to the test suite.

I also performed some cleanup on the fatal and warn functions so they just use the built in version instead of duplicating that functionality in our code.

I updated the tests by getting rid of the unnecessary const testString (we only used it in validation and it looks cleaner using "foo\n" in the expect instead of testString + "\n") I also made it so the tests actually testing something. As it was they all only made sure that something printed not that a prefix was added correctly. I have corrected this.

I also added comments (though not the most descriptive) such that a godoc can be generated.
